### PR TITLE
Feature/clone project

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "cookiestore": "^1.0.3",
     "cuid": "^1.3.8",
     "drumstick": "^1.0.8",
-    "graphcool-metrics": "^0.2.0",
+    "graphcool-metrics": "0.2.1",
     "graphcool-styles": "^0.0.55",
     "graphiql": "^0.8.0",
     "immutable": "^3.8.1",

--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -1,0 +1,98 @@
+import * as React            from 'react' // tslint:disable-line
+import {
+  $p,
+  variables,
+  Icon
+}                            from 'graphcool-styles'
+import styled                from 'styled-components'
+import * as cx               from 'classnames'
+
+const ConditionButton = styled.div`
+  &:not(.${$p.bgBlue}):hover {
+    background-color: ${variables.gray10};
+  }
+`
+
+const CheckIcon = styled(Icon)`
+  background-color: #4990E2;
+  display: inline-flex !important;
+  vertical-align: middle;
+  padding: 5px;
+  margin-right: 15px;
+  border-radius: 50%;
+`
+
+const CheckIconDisabled = styled.div`
+  background-color: ${variables.white};
+  display: inline-flex !important;
+  vertical-align: middle;
+  padding: 12px;
+  margin-right: 15px;
+  border-radius: 50%;
+  border: 1px solid black;
+  opacity: 0.16;
+`
+
+const NestedCheckboxVerticalLine = styled.span`
+  position: absolute;
+  top: -25px;
+  left: 0;
+  height: 45px;
+  border-left-width: 1px;
+  border-left-style: solid;
+`
+const NestedCheckboxHorizontalLine = styled.span`
+  position: absolute;
+  width: 15px;
+  height: 0;
+  top: 20px;
+  left: 0;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
+`
+
+interface Props {
+  label: string
+  onClick: () => void
+  checked: boolean
+  nested: boolean
+  forceHighlightVerticalLine: boolean
+}
+
+export default (props: Props) => {
+  const nestedLines = props.nested && ([
+    <NestedCheckboxVerticalLine key={0} className={cx({
+       [$p.bBlue]: props.checked || props.forceHighlightVerticalLine,
+       [$p.bBlack20]: !props.checked
+    })}/>,
+    <NestedCheckboxHorizontalLine key={1} className={cx({
+       [$p.bBlue]: props.checked,
+       [$p.bBlack20]: !props.checked
+    })}/>
+  ])
+
+  const icon = props.checked
+    ? <CheckIcon
+        color='white'
+        src={require('../../assets/icons/check.svg')}
+      />
+    : <CheckIconDisabled />
+
+  return (
+    <div
+      className={cx($p.relative, $p.mv6, $p.pointer, {
+        [$p.pl16]: props.nested,
+        [$p.z2]: !props.nested
+      })}
+      onClick={props.onClick}
+     >
+      { nestedLines }
+      { icon }
+      <span className={cx($p.dib, $p.vMid, {
+        [$p.black30]: !props.checked
+      })}>
+        { props.label }
+      </span>
+    </div>
+  )
+}

--- a/src/components/Form/Checkbox.tsx
+++ b/src/components/Form/Checkbox.tsx
@@ -2,7 +2,7 @@ import * as React            from 'react' // tslint:disable-line
 import {
   $p,
   variables,
-  Icon
+  Icon,
 }                            from 'graphcool-styles'
 import styled                from 'styled-components'
 import * as cx               from 'classnames'
@@ -53,22 +53,22 @@ const NestedCheckboxHorizontalLine = styled.span`
 
 interface Props {
   label: string
-  onClick: () => void
   checked: boolean
-  nested: boolean
-  forceHighlightVerticalLine: boolean
+  onClick?: () => void
+  nested?: boolean
+  forceHighlightVerticalLine?: boolean
 }
 
 export default (props: Props) => {
   const nestedLines = props.nested && ([
     <NestedCheckboxVerticalLine key={0} className={cx({
        [$p.bBlue]: props.checked || props.forceHighlightVerticalLine,
-       [$p.bBlack20]: !props.checked
+       [$p.bBlack20]: !props.checked,
     })}/>,
     <NestedCheckboxHorizontalLine key={1} className={cx({
        [$p.bBlue]: props.checked,
-       [$p.bBlack20]: !props.checked
-    })}/>
+       [$p.bBlack20]: !props.checked,
+    })}/>,
   ])
 
   const icon = props.checked
@@ -82,14 +82,14 @@ export default (props: Props) => {
     <div
       className={cx($p.relative, $p.mv6, $p.pointer, {
         [$p.pl16]: props.nested,
-        [$p.z2]: !props.nested
+        [$p.z2]: !props.nested,
       })}
       onClick={props.onClick}
      >
       { nestedLines }
       { icon }
       <span className={cx($p.dib, $p.vMid, {
-        [$p.black30]: !props.checked
+        [$p.black30]: !props.checked,
       })}>
         { props.label }
       </span>

--- a/src/components/ProjectSelection/ProjectSelection.tsx
+++ b/src/components/ProjectSelection/ProjectSelection.tsx
@@ -43,6 +43,115 @@ interface State {
   userDropdownVisible: boolean,
 }
 
+const expandedRoot = `
+  background: ${variables.green} !important
+`
+
+const Root = styled.div`
+  &:hover {
+
+  }
+  ${props => props.expanded && expandedRoot}
+
+`
+
+const turnedArrow = `
+  transform: rotate(180deg);
+  background: ${variables.gray20};
+  svg {
+    position: relative;
+    top: 1px;
+  }
+`
+
+const Arrow = styled.div`
+  svg {
+    stroke: ${variables.white};
+    stroke-width: 4px;
+  }
+
+  ${props => props.turned && turnedArrow }
+`
+
+const SettingsLink = styled(Link)`
+  padding: ${variables.size10};
+  background: ${variables.gray10};
+  font-size: ${variables.size14};
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 1px;
+  color: ${variables.white60};
+  width: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-radius: 2px;
+  transition: color ${variables.duration} linear, background ${variables.duration} linear;
+
+  svg {
+    fill: ${variables.white60};
+    transition: fill ${variables.duration} linear;
+  }
+
+  > div {
+    margin-left: 10px;
+  }
+
+  &:hover {
+    color: ${variables.white};
+    background: ${variables.gray20};
+
+    svg {
+      fill: ${variables.white};
+    }
+  }
+`
+
+const activeListItem = `
+  color: ${variables.white};
+
+  &:before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: ${variables.size06};
+    background: ${variables.white};
+    border-radius: 0 2px 2px 0;
+  }
+`
+
+const ListItem = styled(Link)`
+  transition: color ${variables.duration} linear;
+
+  svg {
+    display: none;
+    fill: ${variables.white};
+  }
+
+  &:hover {
+    color: ${variables.white};
+
+    svg {
+      display: block;
+    }
+  }
+
+  ${props => props.active && activeListItem}
+`
+
+const AddProject = styled.div`
+  margin: -3px -4px 0 0;
+
+  svg {
+    stroke: ${variables.white};
+    stroke-width: 4px;
+  }
+`
+
+
 class ProjectSelection extends React.Component<Props, State> {
 
   state = {
@@ -82,144 +191,17 @@ class ProjectSelection extends React.Component<Props, State> {
   }
 
   render () {
-    const expandedRoot = `
-      background: ${variables.green} !important
-    `
-
-    const Root = styled.div`
-      &:hover {
-
-      }
-      ${props => props.expanded && expandedRoot}
-
-    `
-
-    const turnedArrow = `
-      transform: rotate(180deg);
-      background: ${variables.gray20};
-      svg {
-        position: relative;
-        top: 1px;
-      }
-    `
-
-    const Arrow = styled.div`
-      svg {
-        stroke: ${variables.white};
-        stroke-width: 4px;
-      }
-
-      ${props => props.turned && turnedArrow }
-    `
-
-    const SettingsLink = styled(Link)`
-      padding: ${variables.size10};
-      background: ${variables.gray10};
-      font-size: ${variables.size14};
-      text-transform: uppercase;
-      font-weight: 600;
-      letter-spacing: 1px;
-      color: ${variables.white60};
-      width: 50%;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      cursor: pointer;
-      border-radius: 2px;
-      transition: color ${variables.duration} linear, background ${variables.duration} linear;
-
-      svg {
-        fill: ${variables.white60};
-        transition: fill ${variables.duration} linear;
-      }
-
-      > div {
-        margin-left: 10px;
-      }
-
-      &:hover {
-        color: ${variables.white};
-        background: ${variables.gray20};
-
-        svg {
-          fill: ${variables.white};
-        }
-      }
-    `
-
-    const activeListItem = `
-      color: ${variables.white};
-
-      &:before {
-        content: "";
-        position: absolute;
-        top: 0;
-        bottom: 0;
-        left: 0;
-        width: ${variables.size06};
-        background: ${variables.white};
-        border-radius: 0 2px 2px 0;
-      }
-    `
-
-    const ListItem = styled(Link)`
-      transition: color ${variables.duration} linear;
-
-      svg {
-        display: none;
-        fill: ${variables.white};
-      }
-
-      &:hover {
-        color: ${variables.white};
-
-        svg {
-          display: block;
-        }
-      }
-
-      ${props => props.active && activeListItem}
-    `
-
-    const AddProject = styled.div`
-      margin: -3px -4px 0 0;
-
-      svg {
-        stroke: ${variables.white};
-        stroke-width: 4px;
-      }
-    `
-
     return (
       <Root
         expanded={this.state.expanded}
-        className={cx(
-          $p.relative,
-          $p.w100,
-          $p.h100,
-          $p.white,
-          $p.z5,
-          $p.bgDarkBlue,
-        )}
+        className={cx($p.relative, $p.w100, $p.h100, $p.white, $p.z5, $p.bgDarkBlue)}
       >
         <div
           onClick={this.toggle}
-          className={cx(
-            $p.h100,
-            $p.w100,
-            $p.f20,
-            $p.flex,
-            $p.itemsCenter,
-          )}
+          className={cx($p.h100, $p.w100, $p.f20, $p.flex, $p.itemsCenter)}
         >
           <div
-            className={cx(
-              $p.bgGreen,
-              $p.flex,
-              $p.itemsCenter,
-              $p.justifyCenter,
-              $p.pointer
-            )}
+            className={cx($p.bgGreen, $p.flex, $p.itemsCenter, $p.justifyCenter, $p.pointer)}
             style={{
               width: '67px',
               height: '67px',
@@ -234,14 +216,7 @@ class ProjectSelection extends React.Component<Props, State> {
             />
           </div>
           <div
-            className={cx(
-              $p.flex,
-              $p.justifyBetween,
-              $p.selfStretch,
-              $p.itemsCenter,
-              $p.ph25,
-              $p.pointer,
-            )}
+            className={cx($p.flex, $p.justifyBetween, $p.selfStretch, $p.itemsCenter, $p.ph25, $p.pointer)}
             style={{
               flexGrow: 2,
             }}
@@ -251,11 +226,7 @@ class ProjectSelection extends React.Component<Props, State> {
             </div>
             <Arrow
               turned={this.state.expanded}
-              className={cx(
-                $p.flex,
-                $p.itemsCenter,
-                $p.brPill,
-              )}
+              className={cx($p.flex, $p.itemsCenter, $p.brPill)}
               style={{
                 marginRight: '-3px',
               }}
@@ -272,23 +243,8 @@ class ProjectSelection extends React.Component<Props, State> {
 
         </div>
         {this.state.expanded &&
-          <div
-            className={cx(
-              $p.absolute,
-              $p.w100,
-              $p.vh100,
-              $p.bgGreen,
-              $p.flex,
-              $p.flexColumn,
-
-            )}
-          >
-
-            <div className={cx(
-              $p.pa25,
-              $p.flex,
-              $p.justifyBetween,
-            )}>
+          <div className={cx($p.absolute, $p.w100, $p.vh100, $p.bgGreen, $p.flex, $p.flexColumn)}>
+            <div className={cx($p.pa25, $p.flex, $p.justifyBetween)}>
               <SettingsLink to={`/${this.props.params.projectName}/settings`}>
                 <Icon width={16} height={16} src={require('graphcool-styles/icons/fill/settings.svg')}/>
                 <div>Settings</div>
@@ -318,11 +274,7 @@ class ProjectSelection extends React.Component<Props, State> {
               </SettingsLink>
             </div>
             <div
-              className={cx(
-                $p.relative,
-                $p.bgBlack07,
-
-              )}
+              className={cx($p.relative, $p.bgBlack07)}
               style={{
                 flexGrow: 2,
               }}

--- a/src/components/ProjectSelection/ProjectSelection.tsx
+++ b/src/components/ProjectSelection/ProjectSelection.tsx
@@ -4,13 +4,17 @@ import * as React                   from 'react'
 import { Link }                     from 'react-router'
 import { connect }                  from 'react-redux'
 import ClickOutside                 from 'react-click-outside'
+import * as PureRenderMixin         from 'react-addons-pure-render-mixin'
 import * as cx                      from 'classnames'
 import styled                       from 'styled-components'
 import {ConsoleEvents}              from 'graphcool-metrics'
 import * as cookiestore             from 'cookiestore'
-import * as PureRenderMixin         from 'react-addons-pure-render-mixin'
 import cuid                         from 'cuid'
-import {particles, variables, Icon} from 'graphcool-styles'
+import {
+  $p,
+  variables,
+  Icon,
+}                                   from 'graphcool-styles'
 
 import ScrollBox                    from '../../components/ScrollBox/ScrollBox'
 import tracker                      from '../../utils/metrics'
@@ -19,6 +23,7 @@ import {ShowNotificationCallback}   from '../../types/utils'
 import {Popup}                      from '../../types/popup'
 import {showNotification}           from '../../actions/notification'
 import {showPopup}                  from '../../actions/popup'
+import CloneProjectPopup            from '../../views/ProjectRootView/CloneProjectPopup'
 
 
 interface Props {
@@ -68,10 +73,9 @@ class ProjectSelection extends React.Component<Props, State> {
 
     const id = cuid()
     this.props.showPopup({
-      element: <ProjectDuplicatePopup
+      element: <CloneProjectPopup
         id={id}
         projectId={projectId}
-        onDuplicateProject={this.props.duplicateProject}
       />,
       id,
     })
@@ -190,30 +194,31 @@ class ProjectSelection extends React.Component<Props, State> {
       <Root
         expanded={this.state.expanded}
         className={cx(
-          particles.relative,
-          particles.w100,
-          particles.h100,
-          particles.white,
-          particles.z5,
-          particles.bgDarkBlue,
+          $p.relative,
+          $p.w100,
+          $p.h100,
+          $p.white,
+          $p.z5,
+          $p.bgDarkBlue,
         )}
       >
         <div
           onClick={this.toggle}
           className={cx(
-            particles.h100,
-            particles.w100,
-            particles.f20,
-            particles.flex,
-            particles.itemsCenter,
+            $p.h100,
+            $p.w100,
+            $p.f20,
+            $p.flex,
+            $p.itemsCenter,
           )}
         >
           <div
             className={cx(
-              particles.bgGreen,
-              particles.flex,
-              particles.itemsCenter,
-              particles.justifyCenter,
+              $p.bgGreen,
+              $p.flex,
+              $p.itemsCenter,
+              $p.justifyCenter,
+              $p.pointer
             )}
             style={{
               width: '67px',
@@ -230,12 +235,12 @@ class ProjectSelection extends React.Component<Props, State> {
           </div>
           <div
             className={cx(
-              particles.flex,
-              particles.justifyBetween,
-              particles.selfStretch,
-              particles.itemsCenter,
-              particles.ph25,
-              particles.pointer,
+              $p.flex,
+              $p.justifyBetween,
+              $p.selfStretch,
+              $p.itemsCenter,
+              $p.ph25,
+              $p.pointer,
             )}
             style={{
               flexGrow: 2,
@@ -247,9 +252,9 @@ class ProjectSelection extends React.Component<Props, State> {
             <Arrow
               turned={this.state.expanded}
               className={cx(
-                particles.flex,
-                particles.itemsCenter,
-                particles.brPill,
+                $p.flex,
+                $p.itemsCenter,
+                $p.brPill,
               )}
               style={{
                 marginRight: '-3px',
@@ -269,26 +274,26 @@ class ProjectSelection extends React.Component<Props, State> {
         {this.state.expanded &&
           <div
             className={cx(
-              particles.absolute,
-              particles.w100,
-              particles.vh100,
-              particles.bgGreen,
-              particles.flex,
-              particles.flexColumn,
+              $p.absolute,
+              $p.w100,
+              $p.vh100,
+              $p.bgGreen,
+              $p.flex,
+              $p.flexColumn,
 
             )}
           >
 
             <div className={cx(
-              particles.pa25,
-              particles.flex,
-              particles.justifyBetween,
+              $p.pa25,
+              $p.flex,
+              $p.justifyBetween,
             )}>
               <SettingsLink to={`/${this.props.params.projectName}/settings`}>
                 <Icon width={16} height={16} src={require('graphcool-styles/icons/fill/settings.svg')}/>
                 <div>Settings</div>
               </SettingsLink>
-              <SettingsLink className={cx(particles.ml10)} onClick={this.openUserDropdown}>
+              <SettingsLink className={cx($p.ml10)} onClick={this.openUserDropdown}>
                 <Icon width={16} height={16} src={require('graphcool-styles/icons/fill/user.svg')}/>
                 <div>Account</div>
                 {this.state.userDropdownVisible &&
@@ -314,8 +319,8 @@ class ProjectSelection extends React.Component<Props, State> {
             </div>
             <div
               className={cx(
-                particles.relative,
-                particles.bgBlack07,
+                $p.relative,
+                $p.bgBlack07,
 
               )}
               style={{
@@ -328,16 +333,16 @@ class ProjectSelection extends React.Component<Props, State> {
                 }}
               >
                 <div className={cx(
-                  particles.lhSolid,
-                  particles.flex,
-                  particles.itemsCenter,
-                  particles.tracked,
-                  particles.ttu,
-                  particles.fw6,
-                  particles.white80,
-                  particles.mt38,
-                  particles.ml25,
-                  particles.mb16,
+                  $p.lhSolid,
+                  $p.flex,
+                  $p.itemsCenter,
+                  $p.tracked,
+                  $p.ttu,
+                  $p.fw6,
+                  $p.white80,
+                  $p.mt38,
+                  $p.ml25,
+                  $p.mb16,
                 )}>
                   All Projects
                 </div>
@@ -345,43 +350,43 @@ class ProjectSelection extends React.Component<Props, State> {
                   <ListItem
                     key={project.name}
                     className={cx(
-                    particles.relative,
-                    particles.db,
-                    particles.f20,
-                    particles.fw4,
-                    particles.ph25,
-                    particles.pv16,
-                    particles.white60,
-                    particles.flex,
-                    particles.justifyBetween,
-                    particles.itemsCenter,
+                    $p.relative,
+                    $p.db,
+                    $p.f20,
+                    $p.fw4,
+                    $p.ph25,
+                    $p.pv16,
+                    $p.white60,
+                    $p.flex,
+                    $p.justifyBetween,
+                    $p.itemsCenter,
                   )}
                     onClick={() => this.onSelectProject(project.id)}
                     to={`/${project.name}`}
                     active={project.id === this.props.selectedProject.id}
                   >
-                    <div className={cx(particles.ml10)}>{project.name}</div>
-                    <div
+                    <div className={cx($p.ml10)}>{project.name}</div>
+                    <Link
+                      to={`/${project.name}/clone`}
                       title='Duplicate'
-                      onClick={(e: any) => this.onDuplicateClick(e, project.id)}
                     >
                       <Icon
                         src={require('graphcool-styles/icons/fill/duplicate.svg')}
                       />
-                    </div>
+                    </Link>
                   </ListItem>
                 ))}
                 <AddProject
                   className={cx(
-                    particles.absolute,
-                    particles.top38,
-                    particles.right25,
-                    particles.lhSolid,
-                    particles.ba,
-                    particles.brPill,
-                    particles.bWhite,
-                    particles.pointer,
-                    particles.o80,
+                    $p.absolute,
+                    $p.top38,
+                    $p.right25,
+                    $p.lhSolid,
+                    $p.ba,
+                    $p.brPill,
+                    $p.bWhite,
+                    $p.pointer,
+                    $p.o80,
                   )}
                   onClick={this.props.add}
                 >
@@ -422,5 +427,4 @@ class ProjectSelection extends React.Component<Props, State> {
 export default connect(null, {
   showNotification,
   showPopup,
-  duplicateProject
 })(ProjectSelection)

--- a/src/components/ProjectSelection/ProjectSelection.tsx
+++ b/src/components/ProjectSelection/ProjectSelection.tsx
@@ -25,7 +25,6 @@ import {showNotification}           from '../../actions/notification'
 import {showPopup}                  from '../../actions/popup'
 import CloneProjectPopup            from '../../views/ProjectRootView/CloneProjectPopup'
 
-
 interface Props {
   params: any
   add: () => void
@@ -151,7 +150,6 @@ const AddProject = styled.div`
   }
 `
 
-
 class ProjectSelection extends React.Component<Props, State> {
 
   state = {
@@ -165,29 +163,6 @@ class ProjectSelection extends React.Component<Props, State> {
     super(props)
 
     this.shouldComponentUpdate = PureRenderMixin.shouldComponentUpdate.bind(this)
-  }
-
-  private toggle = () => {
-    this.setState({ expanded: !this.state.expanded } as State)
-  }
-
-  private onSelectProject = (id: string) => {
-    this.toggle()
-
-    tracker.track(ConsoleEvents.Project.selected({id}))
-  }
-
-  private onDuplicateClick = (e: any, projectId: string) => {
-    e.preventDefault() // To prevent switching the project
-
-    const id = cuid()
-    this.props.showPopup({
-      element: <CloneProjectPopup
-        id={id}
-        projectId={projectId}
-      />,
-      id,
-    })
   }
 
   render () {
@@ -351,6 +326,16 @@ class ProjectSelection extends React.Component<Props, State> {
         }
       </Root>
     )
+  }
+
+  private toggle = () => {
+    this.setState({ expanded: !this.state.expanded } as State)
+  }
+
+  private onSelectProject = (id: string) => {
+    this.toggle()
+
+    tracker.track(ConsoleEvents.Project.selected({id}))
   }
 
   private closeProjectsList = () => {

--- a/src/mutations/CloneProjectMutation.ts
+++ b/src/mutations/CloneProjectMutation.ts
@@ -1,0 +1,46 @@
+import * as Relay from 'react-relay'
+
+interface Props {
+  projectId: string
+  name: string
+  customerId: string
+  includeData: boolean
+  includeMutationCallbacks: boolean
+}
+
+export default class CloneProjectMutation extends Relay.Mutation<Props, {}> {
+  getMutation () {
+    return Relay.QL`mutation{cloneProject}`
+  }
+
+  getFatQuery () {
+    return Relay.QL`
+      fragment on CloneProjectPayload {
+        projectEdge
+        user
+      }
+    `
+  }
+
+  getConfigs () {
+    return [{
+      type: 'RANGE_ADD',
+      parentName: 'user',
+      parentID: this.props.customerId,
+      connectionName: 'projects',
+      edgeName: 'projectEdge',
+      rangeBehaviors: {
+        '': 'append',
+      },
+    }]
+  }
+
+  getVariables () {
+    return {
+      projectId: this.props.projectId,
+      name: this.props.name,
+      includeData: this.props.includeData,
+      includeMutationCallbacks: this.props.includeMutationCallbacks
+    }
+  }
+}

--- a/src/mutations/CloneProjectMutation.ts
+++ b/src/mutations/CloneProjectMutation.ts
@@ -40,7 +40,7 @@ export default class CloneProjectMutation extends Relay.Mutation<Props, {}> {
       projectId: this.props.projectId,
       name: this.props.name,
       includeData: this.props.includeData,
-      includeMutationCallbacks: this.props.includeMutationCallbacks
+      includeMutationCallbacks: this.props.includeMutationCallbacks,
     }
   }
 }

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -24,6 +24,7 @@ import SchemaView from './views/models/SchemaView/SchemaView'
 import PlaygroundView from './views/playground/PlaygroundView/PlaygroundView'
 import PermissionsView from './views/PermissionsView/PermissionsView'
 import {EditPermissionPopup, AddPermissionPopup} from './views/PermissionsView/PermissionPopup/PermissionPopup'
+import CloneProjectPopup from './views/ProjectRootView/CloneProjectPopup'
 import ShowRoom from './views/ShowRoom/ShowRoom'
 import tracker from './utils/metrics'
 import {ConsoleEvents} from 'graphcool-metrics'
@@ -99,6 +100,7 @@ export default (
     <Route path='signup' component={SignUpView} />
     <Route path='showroom' component={ShowRoom} />
     <Route path=':projectName' component={ProjectRootView} queries={ViewerQuery} render={render}>
+      <Route path='clone' component={CloneProjectPopup} queries={ViewerQuery} render={render} />
       <Route path='account' component={AccountView} queries={ViewerQuery} render={render}>
         <Route path='settings' component={SettingsTab} queries={ViewerQuery} render={render} />
         <IndexRedirect to='settings' />

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -102,8 +102,7 @@ class CloneProjectPopup extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    // TODO: Track
-    // tracker.track(ConsoleEvents.Project.ClonePopup.opened())
+    tracker.track(ConsoleEvents.Project.ClonePopup.opened())
   }
 
   render() {
@@ -174,8 +173,7 @@ class CloneProjectPopup extends React.Component<Props, State> {
   }
 
   private onCancelClick = () => {
-    // TODO: Track
-    // tracker.track(ConsoleEvents.Project.ClonePopup.canceled())
+    tracker.track(ConsoleEvents.Project.ClonePopup.canceled())
 
     this.closePopup()
   }
@@ -207,25 +205,23 @@ class CloneProjectPopup extends React.Component<Props, State> {
       return
     }
 
-    // TODO: track
-    // tracker.track(ConsoleEvents.Project.ClonePopup.submitted({
-    //   includeData,
-    //   includeMutationCallbacks
-    //   name: projectName,
-    // }))
+    tracker.track(ConsoleEvents.Project.ClonePopup.submitted({
+      name: projectName,
+      includeData,
+      includeMutationCallbacks,
+    }))
 
     Relay.Store.commitUpdate(
       new CloneProjectMutation({
-        customerId,
         projectId,
+        name: projectName,
+        customerId,
         includeData,
         includeMutationCallbacks,
-        name: projectName,
       }),
       {
         onSuccess: () => {
-          // TODO: track
-          // tracker.track(ConsoleEvents.Project.cloned({ name: projectName }))
+          tracker.track(ConsoleEvents.Project.cloned({ name: projectName }))
 
           const {router} = this.props
 

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -234,8 +234,8 @@ class CloneProjectPopup extends React.Component<Props, State> {
 }
 
 const MappedCloneProjectPopup = mapProps({
-  projectId: props => props.viewer && props.viewer.project && props.viewer.project.id || null,
-  customerId: props => props.viewer && props.viewer.user && props.viewer.user.id || null,
+  projectId: props => props.viewer && props.viewer.project.id || null,
+  customerId: props => props.viewer && props.viewer.user.id || null,
 })(CloneProjectPopup)
 
 export default Relay.createContainer(withRouter(MappedCloneProjectPopup), {

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -225,13 +225,11 @@ class CloneProjectPopup extends React.Component<Props, State> {
       {
         onSuccess: () => {
           // TODO: track
-          // tracker.track(ConsoleEvents.Project.cloned({
-          //   includeData,
-          //   includeMutationCallbacks
-          //   name: projectName,
-          // }))
+          // tracker.track(ConsoleEvents.Project.cloned({ name: projectName }))
 
-          this.closePopup()
+          const {router} = this.props
+
+          router.push(`/${projectName}`)
         },
         onFailure: (transaction) => console.log(transaction),
       },

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -18,6 +18,7 @@ import tracker               from '../../utils/metrics'
 import mapProps              from '../../components/MapProps/MapProps'
 
 import CloneProjectMutation  from '../../mutations/CloneProjectMutation'
+import Checkbox              from '../../components/Form/Checkbox'
 
 interface Props {
   router: ReactRouter.InjectedRouter
@@ -31,6 +32,66 @@ interface State {
   includeData: boolean
   includeMutationCallbacks: boolean
 }
+
+const Popup = styled.div`
+  width: 600px;
+  max-width: 90%;
+`
+
+const NameInput = styled.input`
+  &::-webkit-input-placeholder {
+  color: ${variables.gray20};
+  opacity: 1;
+}
+  &::-moz-placeholder {
+    color: ${variables.gray20};
+    opacity: 1;
+  }
+  &:-ms-input-placeholder {
+    color: ${variables.gray20};
+    opacity: 1;
+  }
+  &:-moz-placeholder {
+    color: ${variables.gray20};
+    opacity: 1;
+  }
+`
+
+const Warning = styled.div`
+  bottom: -44px;
+`
+
+const Button = styled.button`
+  padding: ${variables.size16};
+  font-size: ${variables.size16};
+  border: none;
+  background: none;
+  color: ${variables.gray50};
+  border-radius: 2px;
+  cursor: pointer;
+  transition: color ${variables.duration} linear;
+
+  &:hover {
+    color: ${variables.gray70};
+  }
+`
+
+const CloneButton = styled(Button)`
+  background: ${variables.green};
+  color: ${variables.white};
+
+  &:hover {
+    color: ${variables.white};
+  }
+`
+
+const MiniHeadline = styled.div`
+  margin-top: -13px;
+`
+
+const NestedCheckboxes = styled.div`
+  padding-left: 12px;
+`
 
 class CloneProjectPopup extends React.Component<Props, State> {
   state = {
@@ -101,118 +162,9 @@ class CloneProjectPopup extends React.Component<Props, State> {
   }
 
   render() {
-    const Popup = styled.div`
-      width: 600px;
-      max-width: 90%;
-    `
-
-    const NameInput = styled.input`
-      &::-webkit-input-placeholder {
-      color: ${variables.gray20};
-      opacity: 1;
-    }
-      &::-moz-placeholder {
-        color: ${variables.gray20};
-        opacity: 1;
-      }
-      &:-ms-input-placeholder {
-        color: ${variables.gray20};
-        opacity: 1;
-      }
-      &:-moz-placeholder {
-        color: ${variables.gray20};
-        opacity: 1;
-      }
-    `
-
-    const Warning = styled.div`
-      bottom: -44px
-    `
-
-    const Button = styled.button`
-      padding: ${variables.size16};
-      font-size: ${variables.size16};
-      border: none;
-      background: none;
-      color: ${variables.gray50};
-      border-radius: 2px;
-      cursor: pointer;
-      transition: color ${variables.duration} linear;
-
-      &:hover {
-        color: ${variables.gray70};
-      }
-    `
-
-    const CheckIcon = styled(Icon)`
-      background-color: #4990E2
-      display: inline-flex !important
-      vertical-align: middle
-      padding: 5px
-      margin-right: 15px
-      border-radius: 50%
-    `
-
-    const CheckIconDisabled = styled.div`
-      background-color: ${variables.white};
-      display: inline-flex !important;
-      vertical-align: middle;
-      padding: 13px;
-      margin-right: 15px;
-      border-radius: 50%;
-      border: 1px solid black;
-      opacity: 0.16;
-    `
-
-    const CloneButton = styled(Button)`
-      background: ${variables.green};
-      color: ${variables.white};
-
-      &:hover {
-        color: ${variables.white};
-      }
-    `
-
-    const NestedCheckbox = styled.div`
-      padding-left: 15px;
-    `
-
-    const NestedCheckboxes = styled.div`
-      padding-left: 12px;
-    `
-
-    const NestedCheckboxVerticalLine = styled.span`
-      position: absolute;
-      top: -25px;
-      left: 0;
-      height: 45px
-      border-left-width: 1px;
-      border-left-style: solid;
-    `
-    const NestedCheckboxHorizontalLine = styled.span`
-      position: absolute;
-      width: 15px;
-      height: 0
-      top: 20px;
-      left: 0;
-      border-bottom-width: 1px;
-      border-bottom-style: solid;
-    `
-
-    const MiniHeadline = styled.div`
-      margin-top: -13px;
-    `
-
     return (
       <div
-        className={cx(
-          $p.flex,
-          $p.bgBlack50,
-          $p.w100,
-          $p.h100,
-          $p.justifyCenter,
-          $p.itemsCenter,
-        )}
+        className={cx($p.flex, $p.bgBlack50, $p.w100, $p.h100, $p.justifyCenter, $p.itemsCenter)}
       >
         <Popup className={cx($p.bgWhite, $p.br2)} style={{pointerEvents: 'all'}}>
           <div className={cx($p.relative, $p.pa60, $p.bb, $p.bBlack20 )}>
@@ -241,66 +193,28 @@ class CloneProjectPopup extends React.Component<Props, State> {
             </p>
           </MiniHeadline>
           <div className={cx($p.pa60, $p.f25, $p.fw3)}>
-            <p className={cx($p.relative, $p.z2, $p.mv6)}>
-              <CheckIcon
-                color='white'
-                src={require('../../assets/icons/check.svg')}
-              />
-              <span className={cx($p.dib, $p.vMid)}>
-                Schema
-              </span>
-            </p>
+            <Checkbox
+              nested={false}
+              checked={true}
+              label='Schema'
+              onClick={() => {}}
+              forceHighlightVerticalLine={false}
+            />
             <NestedCheckboxes>
-              <NestedCheckbox
-                className={cx($p.relative, $p.mv6, $p.pointer)}
+              <Checkbox
+                checked={this.state.includeData}
                 onClick={this.onIncludeDataToggle}
-               >
-                <NestedCheckboxVerticalLine style={{
-                  borderColor: this.state.includeData || this.state.includeMutationCallbacks
-                    ? variables.pblue
-                    : 'rgba(0,0,0,0.2)'
-                }}/>
-                <NestedCheckboxHorizontalLine style={{
-                  borderColor: this.state.includeData ? variables.pblue : 'rgba(0,0,0,0.2)'
-                }}/>
-                {
-                  this.state.includeData
-                    ? <CheckIcon
-                        color='white'
-                        src={require('../../assets/icons/check.svg')}
-                      />
-                    : <CheckIconDisabled />
-                }
-                <span className={cx($p.dib, $p.vMid, {
-                  [$p.black30]: !this.state.includeData
-                })}>
-                  Data
-                </span>
-              </NestedCheckbox>
-              <NestedCheckbox
-                className={cx($p.relative, $p.mv6, $p.pointer)}
+                nested={true}
+                label='Data'
+                forceHighlightVerticalLine={this.state.includeMutationCallbacks}
+              />
+              <Checkbox
+                checked={this.state.includeMutationCallbacks}
                 onClick={this.onIncludeMutationCallbacksToggle}
-              >
-                <NestedCheckboxVerticalLine style={{
-                  borderColor: this.state.includeMutationCallbacks ? variables.pblue : 'rgba(0,0,0,0.2)'
-                }}/>
-                <NestedCheckboxHorizontalLine style={{
-                  borderColor: this.state.includeMutationCallbacks ? variables.pblue : 'rgba(0,0,0,0.2)'
-                }}/>
-                {
-                  this.state.includeMutationCallbacks
-                    ? <CheckIcon
-                        color='white'
-                        src={require('../../assets/icons/check.svg')}
-                      />
-                    : <CheckIconDisabled />
-                }
-                <span className={cx($p.dib, $p.vMid, {
-                  [$p.black30]: !this.state.includeMutationCallbacks
-                 })}>
-                  Mutation Callbacks
-                </span>
-              </NestedCheckbox>
+                nested={true}
+                label='Mutation Callbacks'
+                forceHighlightVerticalLine={false}
+              />
             </NestedCheckboxes>
           </div>
           <div

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -1,0 +1,225 @@
+import * as React            from 'react'
+import * as ReactDOM         from 'react-dom'
+import {connect}             from 'react-redux'
+import {ConsoleEvents}       from 'graphcool-metrics'
+import * as cx               from 'classnames'
+import styled                from 'styled-components'
+import {
+  $p,
+  variables,
+  Icon,
+}                            from 'graphcool-styles'
+
+import {validateProjectName} from '../../utils/nameValidator'
+import tracker               from '../../utils/metrics'
+
+import {ReduxAction}         from '../../types/reducers'
+import {closePopup}          from '../../actions/popup'
+
+interface Props {
+  id: string
+  modelName: string
+  duplicateProject: (projectName: string) => ReduxAction
+  closePopup: (id: string) => ReduxAction
+}
+
+interface State {
+  showError: boolean
+}
+
+class ClodeProjectPopup extends React.Component<Props, State> {
+  refs: {
+    input: HTMLInputElement,
+  }
+
+  state = {
+    showError: false,
+  }
+
+  private saveProject = () => {
+    const projectName = (ReactDOM.findDOMNode(this.refs.input) as HTMLInputElement).value
+
+    tracker.track(ConsoleEvents.Schema.Model.Popup.submitted({type: 'Update', name: projectName}))
+
+    if (projectName != null && !validateProjectName(projectName)) {
+      this.setState({showError: true} as State)
+
+      return
+    }
+
+    this.props.duplicateProject(projectName)
+    this.props.closePopup(this.props.id)
+  }
+
+  private onCancelClick = () => {
+    this.props.closePopup(this.props.id)
+    tracker.track(ConsoleEvents.Schema.Model.Popup.canceled({type: 'Update'}))
+  }
+
+  componentDidMount() {
+    tracker.track(ConsoleEvents.Schema.Model.Popup.opened({type: 'Update'}))
+  }
+
+  render() {
+    const Popup = styled.div`
+      width: 600px;
+      max-width: 90%;
+    `
+
+    const NameInput = styled.input`
+      &::-webkit-input-placeholder {
+      color: ${variables.gray20};
+      opacity: 1;
+    }
+      &::-moz-placeholder {
+        color: ${variables.gray20};
+        opacity: 1;
+      }
+      &:-ms-input-placeholder {
+        color: ${variables.gray20};
+        opacity: 1;
+      }
+      &:-moz-placeholder {
+        color: ${variables.gray20};
+        opacity: 1;
+      }
+    `
+
+    const Warning = styled.div`
+      bottom: -44px
+    `
+
+    const Button = styled.button`
+      padding: ${variables.size16};
+      font-size: ${variables.size16};
+      border: none;
+      background: none;
+      color: ${variables.gray50};
+      border-radius: 2px;
+      cursor: pointer;
+      transition: color ${variables.duration} linear;
+
+      &:hover {
+        color: ${variables.gray70};
+      }
+    `
+
+    const CheckIcon = styled(Icon)`
+      background-color: #4990E2
+      display: inline-flex !important
+      vertical-align: middle
+      padding: 5px
+      margin-right: 15px
+      border-radius: 50%
+    `
+
+    const CloneButton = styled(Button)`
+      background: ${variables.green};
+      color: ${variables.white};
+
+      &:hover {
+        color: ${variables.white};
+      }
+    `
+
+    return (
+      <div
+        className={cx(
+          $p.flex,
+          $p.bgBlack50,
+          $p.w100,
+          $p.h100,
+          $p.justifyCenter,
+          $p.itemsCenter,
+        )}
+      >
+        <Popup className={cx($p.bgWhite, $p.br2)} style={{pointerEvents: 'all'}}>
+          <div className={cx($p.relative, $p.pa60)}>
+            <div className={cx($p.relative)}>
+              {this.state.showError && (
+                <Warning
+                  className={cx(
+                  $p.absolute,
+                  $p.left0,
+                  $p.orange,
+                  $p.f14,
+                )}
+                >
+                  Models must begin with an uppercase letter and only contain letters and numbers
+                </Warning>
+              )}
+              <NameInput
+                className={cx(
+                  $p.fw3,
+                  $p.f38,
+                  $p.bNone,
+                  $p.lhSolid,
+                  $p.tl,
+                )}
+                type='text'
+                autoFocus
+                placeholder='Clone of Instagram...'
+                onKeyDown={e => e.keyCode === 13 && this.saveProject()}
+                ref='input'
+              />
+            </div>
+          </div>
+          <div className={cx($p.pa60, $p.f25, $p.fw3)}>
+            <p className={cx($p.mv6)}>
+              <CheckIcon
+                color="white"
+                src={require('../../assets/icons/check.svg')}
+              />
+              <span className={cx($p.dib, $p.vMid)}>
+                Schema
+              </span>
+            </p>
+            <div className={cx($p.pl25)}>
+              <p className={cx($p.mv6)}>
+                <CheckIcon
+                  color="white"
+                  src={require('../../assets/icons/check.svg')}
+                />
+                <span className={cx($p.dib, $p.vMid)}>
+                  Data
+                </span>
+              </p>
+              <p className={cx($p.mv6)}>
+                <CheckIcon
+                  color="white"
+                  src={require('../../assets/icons/check.svg')}
+                />
+                <span className={cx($p.dib, $p.vMid)}>
+                  Mutation Callbacks
+                </span>
+              </p>
+            </div>
+          </div>
+          <div
+            className={cx(
+              $p.bt,
+              $p.bBlack10,
+              $p.pa25,
+              $p.flex,
+              $p.justifyBetween,
+            )}
+          >
+            <Button onClick={this.onCancelClick}>
+              Cancel
+            </Button>
+            <CloneButton onClick={this.saveProject}>
+              Clone
+            </CloneButton>
+          </div>
+        </Popup>
+      </div>
+    )
+  }
+}
+
+export default connect(
+  null,
+  {
+    closePopup,
+  },
+)(ClodeProjectPopup)

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -102,7 +102,8 @@ class CloneProjectPopup extends React.Component<Props, State> {
   }
 
   componentDidMount() {
-    tracker.track(ConsoleEvents.Schema.Model.Popup.opened({type: 'Update'}))
+    // TODO: Track
+    // tracker.track(ConsoleEvents.Project.ClonePopup.opened())
   }
 
   render() {
@@ -174,21 +175,20 @@ class CloneProjectPopup extends React.Component<Props, State> {
 
   private onCancelClick = () => {
     // TODO: Track
+    // tracker.track(ConsoleEvents.Project.ClonePopup.canceled())
+
     this.closePopup()
   }
 
   private onProjectNameChange = (e: any) => {
-    // TODO: track
     this.setState({ projectName: e.target.value } as State)
   }
 
   private onIncludeDataToggle = () => {
-    // TODO: track
     this.setState({ includeData: !this.state.includeData } as State)
   }
 
   private onIncludeMutationCallbacksToggle = () => {
-    // TODO: track
     this.setState({ includeMutationCallbacks: !this.state.includeMutationCallbacks } as State)
   }
 
@@ -208,9 +208,10 @@ class CloneProjectPopup extends React.Component<Props, State> {
     }
 
     // TODO: track
-    // tracker.track(ConsoleEvents.Permissions.Popup.submitted({
-    //   type: 'Update',
-    //   name: projectName
+    // tracker.track(ConsoleEvents.Project.ClonePopup.submitted({
+    //   includeData,
+    //   includeMutationCallbacks
+    //   name: projectName,
     // }))
 
     Relay.Store.commitUpdate(
@@ -222,7 +223,16 @@ class CloneProjectPopup extends React.Component<Props, State> {
         name: projectName,
       }),
       {
-        onSuccess: () => this.closePopup(),
+        onSuccess: () => {
+          // TODO: track
+          // tracker.track(ConsoleEvents.Project.cloned({
+          //   includeData,
+          //   includeMutationCallbacks
+          //   name: projectName,
+          // }))
+
+          this.closePopup()
+        },
         onFailure: (transaction) => console.log(transaction),
       },
     )

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -101,62 +101,6 @@ class CloneProjectPopup extends React.Component<Props, State> {
     includeMutationCallbacks: false,
   }
 
-  private onCancelClick = () => {
-    // TODO: Track
-    this.closePopup()
-  }
-
-  private onProjectNameChange = (e: any) => {
-    // TODO: track
-    this.setState({ projectName: e.target.value } as State)
-  }
-
-  private onIncludeDataToggle = () => {
-    // TODO: track
-    this.setState({ includeData: !this.state.includeData } as State)
-  }
-
-  private onIncludeMutationCallbacksToggle = () => {
-    // TODO: track
-    this.setState({ includeMutationCallbacks: !this.state.includeMutationCallbacks } as State)
-  }
-
-  private closePopup = () => {
-    this.props.router.goBack()
-  }
-
-  private cloneProject = () => {
-    const { projectId, customerId } = this.props
-    const { projectName, includeData, includeMutationCallbacks } = this.state;
-
-    if (projectName != null && !validateProjectName(projectName)) {
-      this.setState({showError: true} as State)
-
-      // Don't submit as long as name is invalid
-      return
-    }
-
-    // TODO: track
-    // tracker.track(ConsoleEvents.Permissions.Popup.submitted({
-    //   type: 'Update',
-    //   name: projectName
-    // }))
-
-    Relay.Store.commitUpdate(
-      new CloneProjectMutation({
-        customerId,
-        projectId,
-        includeData,
-        includeMutationCallbacks,
-        name: projectName,
-      }),
-      {
-        onSuccess: () => this.closePopup(),
-        onFailure: (transaction) => console.log(transaction),
-      },
-    )
-  }
-
   componentDidMount() {
     tracker.track(ConsoleEvents.Schema.Model.Popup.opened({type: 'Update'}))
   }
@@ -194,11 +138,8 @@ class CloneProjectPopup extends React.Component<Props, State> {
           </MiniHeadline>
           <div className={cx($p.pa60, $p.f25, $p.fw3)}>
             <Checkbox
-              nested={false}
               checked={true}
               label='Schema'
-              onClick={() => {}}
-              forceHighlightVerticalLine={false}
             />
             <NestedCheckboxes>
               <Checkbox
@@ -213,7 +154,6 @@ class CloneProjectPopup extends React.Component<Props, State> {
                 onClick={this.onIncludeMutationCallbacksToggle}
                 nested={true}
                 label='Mutation Callbacks'
-                forceHighlightVerticalLine={false}
               />
             </NestedCheckboxes>
           </div>
@@ -229,6 +169,62 @@ class CloneProjectPopup extends React.Component<Props, State> {
           </div>
         </Popup>
       </div>
+    )
+  }
+
+  private onCancelClick = () => {
+    // TODO: Track
+    this.closePopup()
+  }
+
+  private onProjectNameChange = (e: any) => {
+    // TODO: track
+    this.setState({ projectName: e.target.value } as State)
+  }
+
+  private onIncludeDataToggle = () => {
+    // TODO: track
+    this.setState({ includeData: !this.state.includeData } as State)
+  }
+
+  private onIncludeMutationCallbacksToggle = () => {
+    // TODO: track
+    this.setState({ includeMutationCallbacks: !this.state.includeMutationCallbacks } as State)
+  }
+
+  private closePopup = () => {
+    this.props.router.goBack()
+  }
+
+  private cloneProject = () => {
+    const { projectId, customerId } = this.props
+    const { projectName, includeData, includeMutationCallbacks } = this.state
+
+    if (projectName != null && !validateProjectName(projectName)) {
+      this.setState({showError: true} as State)
+
+      // Don't submit as long as name is invalid
+      return
+    }
+
+    // TODO: track
+    // tracker.track(ConsoleEvents.Permissions.Popup.submitted({
+    //   type: 'Update',
+    //   name: projectName
+    // }))
+
+    Relay.Store.commitUpdate(
+      new CloneProjectMutation({
+        customerId,
+        projectId,
+        includeData,
+        includeMutationCallbacks,
+        name: projectName,
+      }),
+      {
+        onSuccess: () => this.closePopup(),
+        onFailure: (transaction) => console.log(transaction),
+      },
     )
   }
 }
@@ -249,5 +245,5 @@ export default Relay.createContainer(withRouter(MappedCloneProjectPopup), {
         project: projectByName(projectName: $projectName) { id }
       }
     `,
-  }
+  },
 })

--- a/src/views/ProjectRootView/CloneProjectPopup.tsx
+++ b/src/views/ProjectRootView/CloneProjectPopup.tsx
@@ -234,8 +234,8 @@ class CloneProjectPopup extends React.Component<Props, State> {
 }
 
 const MappedCloneProjectPopup = mapProps({
-  projectId: props => props.viewer && props.viewer.project.id || null,
-  customerId: props => props.viewer && props.viewer.user.id || null,
+  projectId: props => props.viewer.project.id,
+  customerId: props => props.viewer.user.id,
 })(CloneProjectPopup)
 
 export default Relay.createContainer(withRouter(MappedCloneProjectPopup), {

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,9 @@
     "tslint-config-standard"
   ],
   "rules": {
+    "no-multi-spaces": {
+      "exceptions": { "ImportDeclaration": true }
+    },
     "trailing-comma": [
       true,
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,27 +409,27 @@ babel-cli@^6.11.4:
   optionalDependencies:
     chokidar "^1.0.0"
 
-babel-code-frame@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.16.0.tgz#f90e60da0862909d3ce098733b5d3987c97cb8de"
+babel-code-frame@^6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
   dependencies:
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^2.0.0"
 
 babel-core@^6.0.0, babel-core@^6.11.4, babel-core@^6.18.0:
-  version "6.18.2"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.18.2.tgz#d8bb14dd6986fa4f3566a26ceda3964fa0e04e5b"
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.20.0.tgz#ab0d7176d9dea434e66badadaf92237865eab1ec"
   dependencies:
-    babel-code-frame "^6.16.0"
-    babel-generator "^6.18.0"
+    babel-code-frame "^6.20.0"
+    babel-generator "^6.20.0"
     babel-helpers "^6.16.0"
     babel-messages "^6.8.0"
     babel-register "^6.18.0"
-    babel-runtime "^6.9.1"
+    babel-runtime "^6.20.0"
     babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
+    babel-traverse "^6.20.0"
+    babel-types "^6.20.0"
     babylon "^6.11.0"
     convert-source-map "^1.1.0"
     debug "^2.1.1"
@@ -441,13 +441,13 @@ babel-core@^6.0.0, babel-core@^6.11.4, babel-core@^6.18.0:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-generator@^6.18.0:
-  version "6.19.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.19.0.tgz#9b2f244204777a3d6810ec127c673c87b349fac5"
+babel-generator@^6.18.0, babel-generator@^6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.20.0.tgz#fee63614e0449390103b3097f3f6a118016c6766"
   dependencies:
     babel-messages "^6.8.0"
-    babel-runtime "^6.9.0"
-    babel-types "^6.19.0"
+    babel-runtime "^6.20.0"
+    babel-types "^6.20.0"
     detect-indent "^4.0.0"
     jsesc "^1.3.0"
     lodash "^4.2.0"
@@ -553,14 +553,14 @@ babel-helper-regex@^6.8.0:
     lodash "^4.2.0"
 
 babel-helper-remap-async-to-generator@^6.16.0, babel-helper-remap-async-to-generator@^6.16.2:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.18.0.tgz#336cdf3cab650bb191b02fc16a3708e7be7f9ce5"
+  version "6.20.3"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.20.3.tgz#9dd3b396f13e35ef63e538098500adc24c63c4e7"
   dependencies:
     babel-helper-function-name "^6.18.0"
-    babel-runtime "^6.0.0"
+    babel-runtime "^6.20.0"
     babel-template "^6.16.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
+    babel-traverse "^6.20.0"
+    babel-types "^6.20.0"
 
 babel-helper-replace-supers@^6.18.0, babel-helper-replace-supers@^6.8.0:
   version "6.18.0"
@@ -700,8 +700,8 @@ babel-plugin-syntax-object-rest-spread@^6.8.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
 babel-plugin-syntax-trailing-function-commas@^6.3.13:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.13.0.tgz#2b84b7d53dd744f94ff1fad7669406274b23f541"
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.20.0.tgz#442835e19179f45b87e92d477d70b9f1f18b5c4f"
 
 babel-plugin-transform-async-generator-functions@^6.17.0:
   version "6.17.0"
@@ -767,13 +767,13 @@ babel-plugin-transform-es2015-block-scoped-functions@^6.3.13:
     babel-runtime "^6.0.0"
 
 babel-plugin-transform-es2015-block-scoping@^6.18.0:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.18.0.tgz#3bfdcfec318d46df22525cdea88f1978813653af"
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.20.0.tgz#5d8f3e83b1a1ae1064e64a9e5bb83108d8e73be3"
   dependencies:
-    babel-runtime "^6.9.0"
+    babel-runtime "^6.20.0"
     babel-template "^6.15.0"
-    babel-traverse "^6.18.0"
-    babel-types "^6.18.0"
+    babel-traverse "^6.20.0"
+    babel-types "^6.20.0"
     lodash "^4.2.0"
 
 babel-plugin-transform-es2015-classes@^6.18.0:
@@ -953,11 +953,11 @@ babel-plugin-transform-function-bind@^6.3.13:
     babel-runtime "^6.0.0"
 
 babel-plugin-transform-object-rest-spread@^6.16.0:
-  version "6.19.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.19.0.tgz#f6ac428ee3cb4c6aa00943ed1422ce813603b34c"
+  version "6.20.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.20.2.tgz#e816c55bba77b14c16365d87e2ae48c8fd18fc2e"
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
-    babel-runtime "^6.0.0"
+    babel-runtime "^6.20.0"
 
 babel-plugin-transform-react-constant-elements@^6.9.1:
   version "6.9.1"
@@ -998,12 +998,10 @@ babel-plugin-transform-react-remove-prop-types@^0.2.7:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.2.11.tgz#05eb7cc4670d6506d801680576589c7abcd51b00"
 
 babel-plugin-transform-regenerator@^6.16.0:
-  version "6.16.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.16.1.tgz#a75de6b048a14154aae14b0122756c5bed392f59"
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.20.0.tgz#a546cd2aa1c9889929d5c427a31303847847ab75"
   dependencies:
-    babel-runtime "^6.9.0"
-    babel-types "^6.16.0"
-    private "~0.1.5"
+    regenerator-transform "0.9.8"
 
 babel-plugin-transform-runtime@^6.9.0:
   version "6.15.0"
@@ -1019,12 +1017,12 @@ babel-plugin-transform-strict-mode@^6.18.0:
     babel-types "^6.18.0"
 
 babel-polyfill@^6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.16.0.tgz#2d45021df87e26a374b6d4d1a9c65964d17f2422"
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.20.0.tgz#de4a371006139e20990aac0be367d398331204e7"
   dependencies:
-    babel-runtime "^6.9.1"
+    babel-runtime "^6.20.0"
     core-js "^2.4.0"
-    regenerator-runtime "^0.9.5"
+    regenerator-runtime "^0.10.0"
 
 babel-preset-es2015@^6.9.0:
   version "6.18.0"
@@ -1141,12 +1139,12 @@ babel-relay-plugin@0.9.3:
   dependencies:
     graphql "^0.6.0"
 
-babel-runtime@6.x, babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.6.1, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
-  version "6.18.0"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.18.0.tgz#0f4177ffd98492ef13b9f823e9994a02584c9078"
+babel-runtime@6.x, babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.6.1, babel-runtime@^6.9.0, babel-runtime@^6.9.1:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.20.0.tgz#87300bdcf4cd770f09bf0048c64204e17806d16f"
   dependencies:
     core-js "^2.4.0"
-    regenerator-runtime "^0.9.5"
+    regenerator-runtime "^0.10.0"
 
 babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0:
   version "6.16.0"
@@ -1158,25 +1156,25 @@ babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-te
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.16.0, babel-traverse@^6.18.0:
-  version "6.19.0"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.19.0.tgz#68363fb821e26247d52a519a84b2ceab8df4f55a"
+babel-traverse@^6.16.0, babel-traverse@^6.18.0, babel-traverse@^6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.20.0.tgz#5378d1a743e3d856e6a52289994100bbdfd9872a"
   dependencies:
-    babel-code-frame "^6.16.0"
+    babel-code-frame "^6.20.0"
     babel-messages "^6.8.0"
-    babel-runtime "^6.9.0"
-    babel-types "^6.19.0"
+    babel-runtime "^6.20.0"
+    babel-types "^6.20.0"
     babylon "^6.11.0"
     debug "^2.2.0"
     globals "^9.0.0"
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.13.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.8.0, babel-types@^6.9.0:
-  version "6.19.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.19.0.tgz#8db2972dbed01f1192a8b602ba1e1e4c516240b9"
+babel-types@^6.13.0, babel-types@^6.16.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.20.0, babel-types@^6.8.0, babel-types@^6.9.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.20.0.tgz#3869ecb98459533b37df809886b3f7f3b08d2baa"
   dependencies:
-    babel-runtime "^6.9.1"
+    babel-runtime "^6.20.0"
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
@@ -1438,8 +1436,8 @@ camelcase@^3.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
 
 caniuse-db@^1.0.30000539, caniuse-db@^1.0.30000578:
-  version "1.0.30000592"
-  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000592.tgz#7b916023941df4063d9d946a1f9ad0d5edaf2bcd"
+  version "1.0.30000595"
+  resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000595.tgz#952e756cda62cd4f563c871cc6401d131bde4186"
 
 capture-stack-trace@^1.0.0:
   version "1.0.0"
@@ -1731,14 +1729,6 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
-concat-stream@^1.4.7:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.5.2.tgz#708978624d856af41a5a741defdd261da752c266"
-  dependencies:
-    inherits "~2.0.1"
-    readable-stream "~2.0.0"
-    typedarray "~0.0.5"
-
 configstore@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-2.1.0.tgz#737a3a7036e9886102aa6099e47bb33ab1aba1a1"
@@ -1849,20 +1839,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2:
     create-hash "^1.1.0"
     inherits "^2.0.1"
 
-cross-spawn-async@^2.0.0:
-  version "2.2.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz#845ff0c0834a3ded9d160daca6d390906bb288cc"
-  dependencies:
-    lru-cache "^4.0.0"
-    which "^1.2.8"
-
-cross-spawn@2.0.x:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-2.0.1.tgz#ab6fd893a099759d9b85220e3a64397de946b0f6"
-  dependencies:
-    cross-spawn-async "^2.0.0"
-    spawn-sync "1.0.13"
-
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -1951,7 +1927,7 @@ css-selector-tokenizer@^0.6.0:
     fastparse "^1.1.1"
     regexpu-core "^1.0.0"
 
-css-to-react-native@^1.0.3:
+css-to-react-native@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-1.0.6.tgz#728c7e774e56536558a0ecaa990d9507c43a4ac4"
   dependencies:
@@ -2881,9 +2857,9 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphcool-metrics@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/graphcool-metrics/-/graphcool-metrics-0.2.0.tgz#05e8e1ef3fbec69930cf411853d1ebb983f8c0f4"
+graphcool-metrics@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/graphcool-metrics/-/graphcool-metrics-0.2.1.tgz#5b59f9a542653818b36fd0564502cf9afc722c06"
 
 graphcool-styles@^0.0.55:
   version "0.0.55"
@@ -3216,7 +3192,7 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
-inline-style-prefixer@^2.0.1, inline-style-prefixer@^2.0.4:
+inline-style-prefixer@^2.0.1, inline-style-prefixer@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-2.0.5.tgz#c153c7e88fd84fef5c602e95a8168b2770671fe7"
   dependencies:
@@ -3331,6 +3307,10 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-function@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -3369,6 +3349,12 @@ is-obj@^1.0.0:
 is-plain-obj@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
+is-plain-object@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.1.tgz#4d7ca539bc9db9b737b8acb612f2318ef92f294f"
+  dependencies:
+    isobject "^1.0.0"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -3431,6 +3417,10 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
 isexe@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-1.1.2.tgz#36f3e22e60750920f5e7241a476a8c6a42275ad0"
+
+isobject@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-1.0.2.tgz#f0f9b8ce92dd540fa0740882e3835a2e022ec78a"
 
 isobject@^2.0.0:
   version "2.1.0"
@@ -4151,7 +4141,7 @@ lowercase-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
-lru-cache@^4.0.0, lru-cache@^4.0.1:
+lru-cache@^4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.0.2.tgz#1d17679c069cda5d040991a09dbc2c0db377e55e"
   dependencies:
@@ -4772,10 +4762,6 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-shim@^0.1.2:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/os-shim/-/os-shim-0.1.3.tgz#6b62c3791cf7909ea35ed46e17658bb417cb3917"
-
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -5177,13 +5163,6 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.1.2"
 
-pre-commit@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/pre-commit/-/pre-commit-1.1.3.tgz#6d5ed90740472072958c711a15f676aa2c231377"
-  dependencies:
-    cross-spawn "2.0.x"
-    which "1.2.x"
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5207,7 +5186,7 @@ pretty-format@~4.2.1:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-4.2.3.tgz#8894c2ac81419cf801629d8f66320a25380d8b05"
 
-private@^0.1.6, private@~0.1.5:
+private@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.6.tgz#55c6a976d0f9bafb9924851350fe47b9b5fbb7c1"
 
@@ -5693,17 +5672,6 @@ readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
-    util-deprecate "~1.0.1"
-
 readable-stream@~2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.1.5.tgz#66fa8b720e1438b364681f2ad1a63c618448c9d0"
@@ -5805,9 +5773,17 @@ regenerate@^1.2.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.2.tgz#d1941c67bad437e1be76433add5b385f95b19260"
 
-regenerator-runtime@^0.9.5:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.9.6.tgz#d33eb95d0d2001a4be39659707c51b0cb71ce029"
+regenerator-runtime@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
+
+regenerator-transform@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.9.8.tgz#0f88bb2bc03932ddb7b6b7312e68078f01026d6c"
+  dependencies:
+    babel-runtime "^6.18.0"
+    babel-types "^6.19.0"
+    private "^0.1.6"
 
 regex-cache@^0.4.2:
   version "0.4.3"
@@ -6156,13 +6132,6 @@ source-map@~0.2.0:
   dependencies:
     amdefine ">=0.0.4"
 
-spawn-sync@1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/spawn-sync/-/spawn-sync-1.0.13.tgz#904091b9ad48a0f3afb0e84752154c01e82fd8d8"
-  dependencies:
-    concat-stream "^1.4.7"
-    os-shim "^0.1.2"
-
 spdx-correct@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-1.0.2.tgz#4b3073d933ff51f3912f03ac5519498a4150db40"
@@ -6308,15 +6277,16 @@ style-loader@^0.13.1:
     loader-utils "^0.2.7"
 
 styled-components@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.1.2.tgz#d9931dc887322ea9b61e7a4fbda25ebd69240854"
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-1.1.3.tgz#9f5b19cff1b53e9063fdf82ccdf024dfd4d68d21"
   dependencies:
     buffer "^5.0.0"
-    css-to-react-native "^1.0.3"
+    css-to-react-native "^1.0.6"
     fbjs "^0.8.4"
     glamor "^2.15.5"
-    inline-style-prefixer "^2.0.4"
-    lodash "^4.15.0"
+    inline-style-prefixer "^2.0.5"
+    is-function "^1.0.1"
+    is-plain-object "^2.0.1"
     supports-color "^3.1.2"
 
 supports-color@^0.2.0:
@@ -6529,10 +6499,6 @@ type-is@~1.6.13:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.13"
-
-typedarray@~0.0.5:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 typescript@2.1.0-dev.20161014:
   version "2.1.0-dev.20161014"
@@ -6905,7 +6871,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@1, which@1.2.x, which@^1.0.5, which@^1.1.1, which@^1.2.8, which@^1.2.9:
+which@1, which@^1.0.5, which@^1.1.1, which@^1.2.9:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:


### PR DESCRIPTION
This PR adds clone project functionality.

- A click on the duplicate icon in the ProjectSelection will Link to a new Route (`/:projectName/clone`)
- That route renders the new Popup (`CloneProjectPopup`).
- Clicking cancel will try to go one route back
- Submitting will close the modal on success

Still todo before ready to merge:

- [x] Extract NestedCheckbox containing check icon + text as an individual component and re-use
- [x] Add tracking
