### PR TITLE
Fixes bug where the clone icon is misplaced

### DIFF
--- a/src/components/ProjectSelection/ProjectSelection.tsx
+++ b/src/components/ProjectSelection/ProjectSelection.tsx
@@ -308,7 +308,6 @@ class ProjectSelection extends React.PureComponent<Props, State> {
                     key={project.name}
                     className={cx(
                         $p.relative,
-                        $p.db,
                         $p.f20,
                         $p.fw4,
                         $p.ph25,


### PR DESCRIPTION
Fixes this:
![image](https://cloud.githubusercontent.com/assets/4989523/26492684/af81fe80-4215-11e7-8264-cb2c5ee5c2d5.png)
