### PR TITLE
Optimize prod bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "npm run lint && jest",
     "test-quick": "jest",
     "test-watch": "jest --watch",
-    "dll": "webpack --config dll.webpack.config.js"
+    "dll": "webpack --config dll.webpack.config.js",
+    "analyze": "source-map-explorer dist/app.*"
   },
   "pre-push": [
     "test-quick"
@@ -167,6 +168,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest-cli": "^16.0.1",
     "json-loader": "^0.5.4",
+    "lodash-webpack-plugin": "^0.11.4",
     "netlify-cli": "^1.0.3",
     "nock": "^8.1.0",
     "node-noop": "^1.0.0",
@@ -177,6 +179,7 @@
     "react-test-renderer": "^15.3.2",
     "redux-mock-store": "^1.2.1",
     "sass-loader": "^4.0.0",
+    "source-map-explorer": "^1.3.3",
     "style-loader": "^0.13.1",
     "svgo-loader": "^1.1.0",
     "tslint": "5.3.2",

--- a/src/utils/example-generation/fake.ts
+++ b/src/utils/example-generation/fake.ts
@@ -1,5 +1,5 @@
 // import * as faker from 'faker'
-const faker = require('faker')
+const faker = require('faker/locale/en_US')
 import cuid from 'cuid'
 
 export function getRandomInt(min: number, max: number) {

--- a/webpack.config.build.js
+++ b/webpack.config.build.js
@@ -8,6 +8,7 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const HappyPack = require('happypack')
 const UglifyJsParallelPlugin = require('webpack-uglify-parallel')
 const os = require('os')
+const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
 
 module.exports = {
   devtool: 'source-map',
@@ -111,6 +112,9 @@ module.exports = {
       },
       sourceMap: true,
     }),
+    // only load en locale for moment see https://github.com/moment/moment/issues/2517#issuecomment-185836313
+    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/),
+    new LodashModuleReplacementPlugin,
     new webpack.NormalModuleReplacementPlugin(/\/iconv-loader$/, 'node-noop'),
     new webpack.optimize.CommonsChunkPlugin('vendor'),
     new webpack.LoaderOptionsPlugin({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -102,6 +102,7 @@ module.exports = {
       template: 'src/index.html',
       templateContent: templateContent(),
     }),
+    new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en/),
     new webpack.NormalModuleReplacementPlugin(/\/iconv-loader$/, 'node-noop'),
     new webpack.optimize.CommonsChunkPlugin('vendor'),
     new webpack.LoaderOptionsPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,6 +1469,10 @@ bser@1.0.2:
   dependencies:
     node-int64 "^0.4.0"
 
+btoa@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.1.2.tgz#3e40b81663f81d2dd6596a4cb714a8dc16cfabe0"
+
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
@@ -1928,7 +1932,7 @@ content-type@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
 
-convert-source-map@1.3.0, convert-source-map@^1.1.0, convert-source-map@^1.3.0:
+convert-source-map@1.3.0, convert-source-map@^1.1.0, convert-source-map@^1.1.1, convert-source-map@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.3.0.tgz#e9f3e9c6e2728efc2676696a70eb382f73106a67"
 
@@ -2337,6 +2341,10 @@ diffie-hellman@^5.0.0:
 discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+
+docopt@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/docopt/-/docopt-0.6.2.tgz#b28e9e2220da5ec49f7ea5bb24a47787405eeb11"
 
 doctrine@^0.7.2:
   version "0.7.2"
@@ -2790,6 +2798,12 @@ file-loader@^0.9.0:
 file-saver@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.3.tgz#cdd4c44d3aa264eac2f68ec165bc791c34af1232"
+
+file-url@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/file-url/-/file-url-1.1.0.tgz#a0f9cf3eb6904c9b1d3a6790b83a976fc40217bb"
+  dependencies:
+    meow "^3.7.0"
 
 filename-regex@^2.0.0:
   version "2.0.0"
@@ -4227,6 +4241,12 @@ loader-utils@^1.0.2:
 lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.4.tgz#dcc1d7552e150a0640073ba9cb31d70f032950e7"
+
+lodash-webpack-plugin@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.4.tgz#6c3ecba3d4b8d24b53940b63542715c5ed3c4ac5"
+  dependencies:
+    lodash "^4.17.4"
 
 lodash._arraycopy@^3.0.0:
   version "3.0.0"
@@ -6712,6 +6732,10 @@ rimraf@2, rimraf@2.x.x, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@~2.5.1, rimraf@~2.5
   dependencies:
     glob "^7.0.5"
 
+rimraf@~2.2.6:
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.2.8.tgz#e439be2aaee327321952730f99a8929e4fc50582"
+
 ripemd160@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-1.0.1.tgz#93a4bbd4942bc574b69a8fa57c71de10ecca7d6e"
@@ -6922,13 +6946,26 @@ source-list-map@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-1.0.1.tgz#cc1fc17122ae0a51978024c2cc0f8c35659026b8"
 
+source-map-explorer@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/source-map-explorer/-/source-map-explorer-1.3.3.tgz#ff15cb038465fb652e57fa54ecd103f51e01bc43"
+  dependencies:
+    btoa "^1.1.2"
+    convert-source-map "^1.1.1"
+    docopt "^0.6.2"
+    file-url "^1.0.1"
+    open "0.0.5"
+    source-map "^0.5.1"
+    temp "^0.8.3"
+    underscore "^1.8.3"
+
 source-map-support@^0.4.0, source-map-support@^0.4.2:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.11.tgz#647f939978b38535909530885303daf23279f322"
   dependencies:
     source-map "^0.5.3"
 
-source-map@0.5.6, source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.6, source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.1, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
@@ -7268,6 +7305,13 @@ tar@^2.0.0, tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/temp/-/temp-0.8.3.tgz#e0c6bc4d26b903124410e4fed81103014dfc1f59"
+  dependencies:
+    os-tmpdir "^1.0.0"
+    rimraf "~2.2.6"
+
 test-exclude@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-2.1.3.tgz#a8d8968e1da83266f9864f2852c55e220f06434a"
@@ -7497,7 +7541,7 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
-underscore@^1.6.0:
+underscore@^1.6.0, underscore@^1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 


### PR DESCRIPTION
The bundle size was 8,11mb.
Now it's 7,25mb.
Reduced almost 1mb of the app bundle size :).
- Only import en locale for fakerjs (1,01mb => 317kb)
- Only import en locale for moment (198kb => 54,2kb)
- lodash (94,7kb => 80,1kb)
- analyze script: start `source-map-explorer`

## Before
![capture d ecran 2017-06-02 a 17 19 11](https://cloud.githubusercontent.com/assets/5749437/26735723/684b571a-47c3-11e7-9c20-8923dddff775.png)

## After
![capture d ecran 2017-06-02 a 18 48 54](https://cloud.githubusercontent.com/assets/5749437/26735899/311f9818-47c4-11e7-940b-c3792de6b5f3.png)

